### PR TITLE
build(deps): update checkout action to v5

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Fetch full history to generate changelog
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm


### PR DESCRIPTION
   Update actions/checkout from v4 to v5 across all workflows for security improvements and latest features.

   - changelog.yml: checkout@v4 → checkout@v5
   - ci.yml: checkout@v4 → checkout@v5 (both instances)
   - deploy-prod.yml: checkout@v4 → checkout@v5
   - deploy-test.yml: checkout@v4 → checkout@v5

   This change maintains full backward compatibility while providing the latest security fixes.

## Summary

- What problem does this PR solve?
- Key changes made:

## Testing

- [ ] `pnpm test`
- [ ] `pnpm run type-check`
- [ ] `pnpm run lint`
- [ ] `pnpm run cf:dev` (if applicable)

## Deployment

- Does this require database migrations? If so, note commands.
- Any Cloudflare binding updates needed?

## Checklist

- [ ] I have updated documentation where needed.
- [ ] I have added or adjusted tests to cover my changes.
- [ ] I have verified that release-please will categorize the commits correctly.
